### PR TITLE
修改pubDate格式为RFC2822并移动到item下，确保qbit可以正确识别日期

### DIFF
--- a/main.py
+++ b/main.py
@@ -41,24 +41,27 @@ def root(token: str):
         # 使用find找到torrent节点，再找到pubDate
         pub_date_element = item.find('.//ns:torrent/ns:pubDate', namespaces)
         if pub_date_element is not None:
-            # 原始pubDate字符串
-            pub_date_str = pub_date_element.text
-            # 去掉微秒部分，转换格式
-            if '.' in pub_date_str:
-                pub_date_str = pub_date_str.split('.')[0]  # 去掉微秒部分
-            # 解析原始日期字符串
-            pub_date = datetime.fromisoformat(pub_date_str)
-            # 将日期格式化为目标格式
-            formatted_pub_date = pub_date.strftime('%a, %d %b %Y %H:%M:%S +0800')
-            # 更新pubDate元素的文本
-            # pub_date_element.text = formatted_pub_date  # 也没必要
+            try:  # 为了防止mikan忽然改格式导致InternalError
+                # 原始pubDate字符串
+                pub_date_str = pub_date_element.text
+                # 去掉微秒部分，转换格式
+                if '.' in pub_date_str:
+                    pub_date_str = pub_date_str.split('.')[0]  # 去掉微秒部分
+                # 解析原始日期字符串
+                pub_date = datetime.fromisoformat(pub_date_str)
+                # 将日期格式化为目标格式
+                formatted_pub_date = pub_date.strftime('%a, %d %b %Y %H:%M:%S +0800')
+                # 更新pubDate元素的文本
+                # pub_date_element.text = formatted_pub_date  # 也没必要
 
-            # 将pubDate元素移动到item下
-            # 创建新的pubDate节点
-            new_pub_date_element = etree.Element('pubDate')
-            new_pub_date_element.text = formatted_pub_date
-            # 将新的pubDate添加到item的最后
-            item.append(new_pub_date_element)
+                # 将pubDate元素移动到item下
+                # 创建新的pubDate节点
+                new_pub_date_element = etree.Element('pubDate')
+                new_pub_date_element.text = formatted_pub_date
+                # 将新的pubDate添加到item的最后
+                item.append(new_pub_date_element)
+            except:
+                continue
 
     content = etree.tostring(doc)
     return Response(content, media_type="application/xml")

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import requests
 import uvicorn
 from fastapi import FastAPI, Response
 from lxml import etree
+from datetime import datetime
 
 run_host = "0.0.0.0"
 run_port = 9115
@@ -33,6 +34,31 @@ def root(token: str):
             f"{host_name}/get?token={user_token}&link=https://mikanani.me",
         )
         link.set("url", url)
+    
+    # 修改pubdate格式
+    namespaces = {'ns': 'https://mikanani.me/0.1/'}
+    for item in doc.findall('.//item'):
+        # 使用find找到torrent节点，再找到pubDate
+        pub_date_element = item.find('.//ns:torrent/ns:pubDate', namespaces)
+        if pub_date_element is not None:
+            # 原始pubDate字符串
+            pub_date_str = pub_date_element.text
+            # 去掉微秒部分，转换格式
+            if '.' in pub_date_str:
+                pub_date_str = pub_date_str.split('.')[0]  # 去掉微秒部分
+            # 解析原始日期字符串
+            pub_date = datetime.fromisoformat(pub_date_str)
+            # 将日期格式化为目标格式
+            formatted_pub_date = pub_date.strftime('%a, %d %b %Y %H:%M:%S +0800')
+            # 更新pubDate元素的文本
+            # pub_date_element.text = formatted_pub_date  # 也没必要
+
+            # 将pubDate元素移动到item下
+            # 创建新的pubDate节点
+            new_pub_date_element = etree.Element('pubDate')
+            new_pub_date_element.text = formatted_pub_date
+            # 将新的pubDate添加到item的最后
+            item.append(new_pub_date_element)
 
     content = etree.tostring(doc)
     return Response(content, media_type="application/xml")


### PR DESCRIPTION
蜜柑提供的RSS里，pubDate在./item/torrent下，无法被qbit识别到。且格式为ISO 8601，也无法被qbit正确识别。  
所以在item下创建了一个pubDate字段，并且转成了能被qbit识别的RFC2822格式

错误识别（识别为添加RSS订阅时的时间）：
![image](https://github.com/user-attachments/assets/96f0cb0b-7b23-45c4-a0bd-cd18d713d5b0)
正确识别：
![image](https://github.com/user-attachments/assets/c24807a2-d547-4539-9622-08651257ffd7)

